### PR TITLE
Re-work vgpu-img to ces2018

### DIFF
--- a/prod-ces2018.xml
+++ b/prod-ces2018.xml
@@ -4,7 +4,7 @@
 
     <default remote="github" sync-j="10" sync-c="true" />
 
-    <project name="xen-troops/meta-xt-prod-devel" path="meta-xt-prod-devel" upstream="vgpu-img" revision="vgpu-img" />
-    <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="vgpu-img" revision="vgpu-img" />
+    <project name="xen-troops/meta-xt-prod-ces2018" path="meta-xt-prod-ces2018" upstream="master" revision="master" />
+    <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="master" revision="master" />
     <project name="xen-troops/xt-distro" path="xt-distro" upstream="master" revision="master" />
 </manifest>


### PR DESCRIPTION
vgpu-img product was only a test one, so re-use it
to become a CES2018 product.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>