### PR TITLE
tu2019: Fix 'fixed' revision to use proper android manifest

### DIFF
--- a/prod-tu2019-demo.xml
+++ b/prod-tu2019-demo.xml
@@ -4,7 +4,7 @@
 
     <default remote="github" sync-j="10" sync-c="true" />
 
-    <project name="xen-troops/meta-xt-prod-tu2019-demo" path="meta-xt-prod-tu2019-demo" upstream="master" revision="a52e256a1ae38bcda82f069b5fa704917f10ce4e" />
+    <project name="xen-troops/meta-xt-prod-tu2019-demo" path="meta-xt-prod-tu2019-demo" upstream="master" revision="f209e88bb64a7ea21bc2d924e1557238002225cd" />
     <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="master" revision="93bfbc76a38778f4df5851faee634c57e6f66487" />
     <project name="xen-troops/xt-distro" path="xt-distro" upstream="master" revision="4c5546194353cca3008ed8d6309c4cc1c03403ff" />
 </manifest>


### PR DESCRIPTION
We fixed product to commit that was used for 'release' version.
But android manifest moved further, so we need to fix not only product
but also android.
Android manifest is fixed as last commit of product.
So this is the reason that we need to fix product not to commit that
was used for release but for commit with fixed android.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>