### PR TITLE
Fix meta-xt-images revision to 3b88643

### DIFF
--- a/prod-aos.xml
+++ b/prod-aos.xml
@@ -6,7 +6,7 @@
     <default remote="github" sync-j="10" sync-c="true" />
 
     <project name="xen-troops/meta-xt-prod-aos" path="meta-xt-prod-aos" upstream="master" revision="master" />
-    <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="master" revision="master" />
+    <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="master" revision="3b886434bfc2e001e52afa33bd0896d16bbe2041" />
     <project name="xen-troops/xt-distro" path="xt-distro" upstream="master" revision="master" />
     <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="master" />
 </manifest>


### PR DESCRIPTION
Latest meta-xt-images changes broke prod-aos build. meta-linaro was
changed to meta-arm which is not compatible with current prod-aos.
Temporary fix meta-xt-images to working revision.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>